### PR TITLE
Add colors from Sphero Rubygem

### DIFF
--- a/dist/adaptor.js
+++ b/dist/adaptor.js
@@ -9,13 +9,15 @@
 
 (function() {
   'use strict';
-  var Spheron, namespace,
+  var Colors, Spheron, namespace,
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
   require('./cylon-sphero');
 
   Spheron = require('spheron');
+
+  Colors = require('./colors');
 
   namespace = require('node-namespace');
 
@@ -71,6 +73,25 @@
 
       Sphero.prototype.setRGB = function(color, persist) {
         return this.sphero.setRGB(color, persist);
+      };
+
+      Sphero.prototype.setColor = function(color, persist) {
+        if (persist == null) {
+          persist = true;
+        }
+        if (typeof color === 'string') {
+          color = Colors.fromString(color);
+        }
+        return this.setRGB(color, persist);
+      };
+
+      Sphero.prototype.setRandomColor = function(persist) {
+        var color;
+        if (persist == null) {
+          persist = true;
+        }
+        color = Colors.randomColor();
+        return this.setRGB(color, persist);
       };
 
       Sphero.prototype.stop = function() {

--- a/dist/colors.js
+++ b/dist/colors.js
@@ -1,0 +1,181 @@
+/*
+ * cylon sphero adaptor
+ * http://cylonjs.com
+ *
+ * Copyright (c) 2013 The Hybrid Group
+ * Licensed under the Apache 2.0 license.
+*/
+
+
+(function() {
+  var Colors;
+
+  Colors = {
+    aliceblue: 0xF0F8FF,
+    antiquewhite: 0xFAEBD7,
+    aqua: 0x00FFFF,
+    aquamarine: 0x7FFFD4,
+    azure: 0xF0FFFF,
+    beige: 0xF5F5DC,
+    bisque: 0xFFE4C4,
+    black: 0x000000,
+    blanchedalmond: 0xFFEBCD,
+    blue: 0x0000FF,
+    blueviolet: 0x8A2BE2,
+    brown: 0xA52A2A,
+    burlywood: 0xDEB887,
+    cadetblue: 0x5F9EA0,
+    chartreuse: 0x7FFF00,
+    chocolate: 0xD2691E,
+    coral: 0xFF7F50,
+    cornflowerblue: 0x6495ED,
+    cornsilk: 0xFFF8DC,
+    crimson: 0xDC143C,
+    cyan: 0x00FFFF,
+    darkblue: 0x00008B,
+    darkcyan: 0x008B8B,
+    darkgoldenrod: 0xB8860B,
+    darkgray: 0xA9A9A9,
+    darkgreen: 0x006400,
+    darkkhaki: 0xBDB76B,
+    darkmagenta: 0x8B008B,
+    darkolivegreen: 0x556B2F,
+    darkorange: 0xFF8C00,
+    darkorchid: 0x9932CC,
+    darkred: 0x8B0000,
+    darksalmon: 0xE9967A,
+    darkseagreen: 0x8FBC8F,
+    darkslateblue: 0x483D8B,
+    darkslategray: 0x2F4F4F,
+    darkturquoise: 0x00CED1,
+    darkviolet: 0x9400D3,
+    deeppink: 0xFF1493,
+    deepskyblue: 0x00BFFF,
+    dimgray: 0x696969,
+    dodgerblue: 0x1E90FF,
+    firebrick: 0xB22222,
+    floralwhite: 0xFFFAF0,
+    forestgreen: 0x228B22,
+    fuchsia: 0xFF00FF,
+    gainsboro: 0xDCDCDC,
+    ghostwhite: 0xF8F8FF,
+    gold: 0xFFD700,
+    goldenrod: 0xDAA520,
+    gray: 0x808080,
+    green: 0x008000,
+    greenyellow: 0xADFF2F,
+    honeydew: 0xF0FFF0,
+    hotpink: 0xFF69B4,
+    indianred: 0xCD5C5C,
+    indigo: 0x4B0082,
+    ivory: 0xFFFFF0,
+    khaki: 0xF0E68C,
+    lavender: 0xE6E6FA,
+    lavenderblush: 0xFFF0F5,
+    lawngreen: 0x7CFC00,
+    lemonchiffon: 0xFFFACD,
+    lightblue: 0xADD8E6,
+    lightcoral: 0xF08080,
+    lightcyan: 0xE0FFFF,
+    lightgoldenrodyellow: 0xFAFAD2,
+    lightgreen: 0x90EE90,
+    lightgrey: 0xD3D3D3,
+    lightpink: 0xFFB6C1,
+    lightsalmon: 0xFFA07A,
+    lightseagreen: 0x20B2AA,
+    lightskyblue: 0x87CEFA,
+    lightslategray: 0x778899,
+    lightsteelblue: 0xB0C4DE,
+    lightyellow: 0xFFFFE0,
+    lime: 0x00FF00,
+    limegreen: 0x32CD32,
+    linen: 0xFAF0E6,
+    magenta: 0xFF00FF,
+    maroon: 0x800000,
+    mediumaquamarine: 0x66CDAA,
+    mediumblue: 0x0000CD,
+    mediumorchid: 0xBA55D3,
+    mediumpurple: 0x9370DB,
+    mediumseagreen: 0x3CB371,
+    mediumslateblue: 0x7B68EE,
+    mediumspringgreen: 0x00FA9A,
+    mediumturquoise: 0x48D1CC,
+    mediumvioletred: 0xC71585,
+    midnightblue: 0x191970,
+    mintcream: 0xF5FFFA,
+    mistyrose: 0xFFE4E1,
+    moccasin: 0xFFE4B5,
+    navajowhite: 0xFFDEAD,
+    navy: 0x000080,
+    oldlace: 0xFDF5E6,
+    olive: 0x808000,
+    olivedrab: 0x6B8E23,
+    orange: 0xFFA500,
+    orangered: 0xFF4500,
+    orchid: 0xDA70D6,
+    palegoldenrod: 0xEEE8AA,
+    palegreen: 0x98FB98,
+    paleturquoise: 0xAFEEEE,
+    palevioletred: 0xDB7093,
+    papayawhip: 0xFFEFD5,
+    peachpuff: 0xFFDAB9,
+    peru: 0xCD853F,
+    pink: 0xFFC0CB,
+    plum: 0xDDA0DD,
+    powderblue: 0xB0E0E6,
+    purple: 0x800080,
+    red: 0xFF0000,
+    rosybrown: 0xBC8F8F,
+    royalblue: 0x4169E1,
+    saddlebrown: 0x8B4513,
+    salmon: 0xFA8072,
+    sandybrown: 0xF4A460,
+    seagreen: 0x2E8B57,
+    seashell: 0xFFF5EE,
+    sienna: 0xA0522D,
+    silver: 0xC0C0C0,
+    skyblue: 0x87CEEB,
+    slateblue: 0x6A5ACD,
+    slategray: 0x708090,
+    snow: 0xFFFAFA,
+    springgreen: 0x00FF7F,
+    steelblue: 0x4682B4,
+    tan: 0xD2B48C,
+    teal: 0x008080,
+    thistle: 0xD8BFD8,
+    tomato: 0xFF6347,
+    turquoise: 0x40E0D0,
+    violet: 0xEE82EE,
+    wheat: 0xF5DEB3,
+    white: 0xFFFFFF,
+    whitesmoke: 0xF5F5F5,
+    yellow: 0xFFFF00,
+    yellowgreen: 0x9ACD32
+  };
+
+  module.exports = {
+    randomColor: function() {
+      var color, colors, n;
+      colors = (function() {
+        var _results;
+        _results = [];
+        for (n in Colors) {
+          color = Colors[n];
+          _results.push(color);
+        }
+        return _results;
+      })();
+      return colors[colors.length * Math.random() << 0];
+    },
+    fromString: function(string) {
+      var message;
+      if (Colors[string] != null) {
+        return Colors[string];
+      } else {
+        message = "No matching color found.\nPlease provide a string color name or literal hex number.";
+        throw message;
+      }
+    }
+  };
+
+}).call(this);

--- a/dist/cylon-sphero.js
+++ b/dist/cylon-sphero.js
@@ -15,7 +15,7 @@
   namespace = require('node-namespace');
 
   namespace("Cylon.Sphero", function() {
-    return this.Commands = ['roll', 'setRGB', 'detectCollisions', 'stop'];
+    return this.Commands = ['roll', 'setRGB', 'detectCollisions', 'setColor', 'stop'];
   });
 
   require('./adaptor');

--- a/src/adaptor.coffee
+++ b/src/adaptor.coffee
@@ -9,7 +9,8 @@
 'use strict';
 
 require './cylon-sphero'
-Spheron = require('spheron')
+Spheron = require 'spheron'
+Colors = require './colors'
 namespace = require 'node-namespace'
 
 namespace "Cylon.Adaptor", ->
@@ -56,6 +57,14 @@ namespace "Cylon.Adaptor", ->
 
     setRGB: (color, persist) ->
       @sphero.setRGB(color, persist)
+
+    setColor: (color, persist = true) ->
+      color = Colors.fromString(color) if typeof color is 'string'
+      @setRGB color, persist
+
+    setRandomColor: (persist = true) ->
+      color = Colors.randomColor()
+      @setRGB color, persist
 
     stop: ->
       @sphero.roll(0, 0, 0)

--- a/src/colors.coffee
+++ b/src/colors.coffee
@@ -1,0 +1,164 @@
+###
+ * cylon sphero adaptor
+ * http://cylonjs.com
+ *
+ * Copyright (c) 2013 The Hybrid Group
+ * Licensed under the Apache 2.0 license.
+###
+
+Colors =
+  aliceblue:             0xF0F8FF
+  antiquewhite:          0xFAEBD7
+  aqua:                  0x00FFFF
+  aquamarine:            0x7FFFD4
+  azure:                 0xF0FFFF
+  beige:                 0xF5F5DC
+  bisque:                0xFFE4C4
+  black:                 0x000000
+  blanchedalmond:        0xFFEBCD
+  blue:                  0x0000FF
+  blueviolet:            0x8A2BE2
+  brown:                 0xA52A2A
+  burlywood:             0xDEB887
+  cadetblue:             0x5F9EA0
+  chartreuse:            0x7FFF00
+  chocolate:             0xD2691E
+  coral:                 0xFF7F50
+  cornflowerblue:        0x6495ED
+  cornsilk:              0xFFF8DC
+  crimson:               0xDC143C
+  cyan:                  0x00FFFF
+  darkblue:              0x00008B
+  darkcyan:              0x008B8B
+  darkgoldenrod:         0xB8860B
+  darkgray:              0xA9A9A9
+  darkgreen:             0x006400
+  darkkhaki:             0xBDB76B
+  darkmagenta:           0x8B008B
+  darkolivegreen:        0x556B2F
+  darkorange:            0xFF8C00
+  darkorchid:            0x9932CC
+  darkred:               0x8B0000
+  darksalmon:            0xE9967A
+  darkseagreen:          0x8FBC8F
+  darkslateblue:         0x483D8B
+  darkslategray:         0x2F4F4F
+  darkturquoise:         0x00CED1
+  darkviolet:            0x9400D3
+  deeppink:              0xFF1493
+  deepskyblue:           0x00BFFF
+  dimgray:               0x696969
+  dodgerblue:            0x1E90FF
+  firebrick:             0xB22222
+  floralwhite:           0xFFFAF0
+  forestgreen:           0x228B22
+  fuchsia:               0xFF00FF
+  gainsboro:             0xDCDCDC
+  ghostwhite:            0xF8F8FF
+  gold:                  0xFFD700
+  goldenrod:             0xDAA520
+  gray:                  0x808080
+  green:                 0x008000
+  greenyellow:           0xADFF2F
+  honeydew:              0xF0FFF0
+  hotpink:               0xFF69B4
+  indianred:             0xCD5C5C
+  indigo:                0x4B0082
+  ivory:                 0xFFFFF0
+  khaki:                 0xF0E68C
+  lavender:              0xE6E6FA
+  lavenderblush:         0xFFF0F5
+  lawngreen:             0x7CFC00
+  lemonchiffon:          0xFFFACD
+  lightblue:             0xADD8E6
+  lightcoral:            0xF08080
+  lightcyan:             0xE0FFFF
+  lightgoldenrodyellow:  0xFAFAD2
+  lightgreen:            0x90EE90
+  lightgrey:             0xD3D3D3
+  lightpink:             0xFFB6C1
+  lightsalmon:           0xFFA07A
+  lightseagreen:         0x20B2AA
+  lightskyblue:          0x87CEFA
+  lightslategray:        0x778899
+  lightsteelblue:        0xB0C4DE
+  lightyellow:           0xFFFFE0
+  lime:                  0x00FF00
+  limegreen:             0x32CD32
+  linen:                 0xFAF0E6
+  magenta:               0xFF00FF
+  maroon:                0x800000
+  mediumaquamarine:      0x66CDAA
+  mediumblue:            0x0000CD
+  mediumorchid:          0xBA55D3
+  mediumpurple:          0x9370DB
+  mediumseagreen:        0x3CB371
+  mediumslateblue:       0x7B68EE
+  mediumspringgreen:     0x00FA9A
+  mediumturquoise:       0x48D1CC
+  mediumvioletred:       0xC71585
+  midnightblue:          0x191970
+  mintcream:             0xF5FFFA
+  mistyrose:             0xFFE4E1
+  moccasin:              0xFFE4B5
+  navajowhite:           0xFFDEAD
+  navy:                  0x000080
+  oldlace:               0xFDF5E6
+  olive:                 0x808000
+  olivedrab:             0x6B8E23
+  orange:                0xFFA500
+  orangered:             0xFF4500
+  orchid:                0xDA70D6
+  palegoldenrod:         0xEEE8AA
+  palegreen:             0x98FB98
+  paleturquoise:         0xAFEEEE
+  palevioletred:         0xDB7093
+  papayawhip:            0xFFEFD5
+  peachpuff:             0xFFDAB9
+  peru:                  0xCD853F
+  pink:                  0xFFC0CB
+  plum:                  0xDDA0DD
+  powderblue:            0xB0E0E6
+  purple:                0x800080
+  red:                   0xFF0000
+  rosybrown:             0xBC8F8F
+  royalblue:             0x4169E1
+  saddlebrown:           0x8B4513
+  salmon:                0xFA8072
+  sandybrown:            0xF4A460
+  seagreen:              0x2E8B57
+  seashell:              0xFFF5EE
+  sienna:                0xA0522D
+  silver:                0xC0C0C0
+  skyblue:               0x87CEEB
+  slateblue:             0x6A5ACD
+  slategray:             0x708090
+  snow:                  0xFFFAFA
+  springgreen:           0x00FF7F
+  steelblue:             0x4682B4
+  tan:                   0xD2B48C
+  teal:                  0x008080
+  thistle:               0xD8BFD8
+  tomato:                0xFF6347
+  turquoise:             0x40E0D0
+  violet:                0xEE82EE
+  wheat:                 0xF5DEB3
+  white:                 0xFFFFFF
+  whitesmoke:            0xF5F5F5
+  yellow:                0xFFFF00
+  yellowgreen:           0x9ACD32
+
+module.exports =
+  randomColor: ->
+    colors = (color for n, color of Colors)
+    colors[colors.length * Math.random() << 0]
+
+  fromString: (string) ->
+    if Colors[string]?
+      Colors[string]
+    else
+      message = """
+        No matching color found.
+        Please provide a string color name or literal hex number.
+      """
+      throw message

--- a/src/cylon-sphero.coffee
+++ b/src/cylon-sphero.coffee
@@ -11,7 +11,7 @@
 namespace = require 'node-namespace'
 
 namespace "Cylon.Sphero", ->
-  @Commands = ['roll', 'setRGB', 'detectCollisions', 'stop']
+  @Commands = ['roll', 'setRGB', 'detectCollisions', 'setColor', 'stop']
 
 require './adaptor'
 require './driver'

--- a/test/dist/specs/colors.spec.js
+++ b/test/dist/specs/colors.spec.js
@@ -1,0 +1,16 @@
+(function() {
+  'use strict';
+  var Colors;
+
+  Colors = source('colors');
+
+  describe('Colors', function() {
+    it('can fetch hex colors from a string', function() {
+      return Colors.fromString('cyan').should.be.equal(0x00FFFF);
+    });
+    return it('can provide random colors', function() {
+      return assert(typeof Colors.randomColor() === 'number');
+    });
+  });
+
+}).call(this);

--- a/test/src/specs/colors.spec.coffee
+++ b/test/src/specs/colors.spec.coffee
@@ -1,0 +1,10 @@
+'use strict';
+
+Colors = source 'colors'
+
+describe 'Colors', ->
+  it 'can fetch hex colors from a string', ->
+    Colors.fromString('cyan').should.be.equal 0x00FFFF
+
+  it 'can provide random colors', ->
+    assert typeof Colors.randomColor() is 'number'


### PR DESCRIPTION
- Adds colors from [Sphero gem](https://github.com/hybridgroup/sphero/blob/d55ef98/lib/sphero.rb#L265)
- Adds function to pick a random color, and to find one from a string
- Adds support for using them in adaptor (setColor and setRandomColor)

Example usage from Cylon:

``` coffeescript
Cylon = require 'cylon'

Cylon.robot
  connection:
    name: 'sphero', adaptor: 'sphero', port: '/dev/rfcomm0'

  device:
    name: 'sphero', driver: 'sphero'

  work: (me) ->
    me.sphero.setColor 'papayawhip'

.start()
```
