### PR TITLE
Use direct object proxy instead of prototype

### DIFF
--- a/dist/adaptor.js
+++ b/dist/adaptor.js
@@ -31,7 +31,7 @@
         this.name = opts.name;
         this.sphero = Spheron.sphero();
         this.connector = this.sphero;
-        this.proxyMethods(Cylon.Sphero.Commands, this.sphero, Sphero);
+        this.proxyMethods(Cylon.Sphero.Commands, this.sphero, this);
       }
 
       Sphero.prototype.commands = function() {

--- a/dist/driver.js
+++ b/dist/driver.js
@@ -25,7 +25,7 @@
         Sphero.__super__.constructor.apply(this, arguments);
         this.device = opts.device;
         this.connection = this.device.connection;
-        this.proxyMethods(Cylon.Sphero.Commands, this.connection, Sphero);
+        this.proxyMethods(Cylon.Sphero.Commands, this.connection, this);
       }
 
       Sphero.prototype.commands = function() {

--- a/src/adaptor.coffee
+++ b/src/adaptor.coffee
@@ -21,7 +21,7 @@ namespace "Cylon.Adaptor", ->
       @name = opts.name
       @sphero = Spheron.sphero()
       @connector = @sphero
-      @proxyMethods Cylon.Sphero.Commands, @sphero, Sphero
+      @proxyMethods Cylon.Sphero.Commands, @sphero, this
 
     commands: -> Cylon.Sphero.Commands
 

--- a/src/driver.coffee
+++ b/src/driver.coffee
@@ -18,7 +18,7 @@ namespace "Cylon.Driver", ->
       super
       @device = opts.device
       @connection = @device.connection
-      @proxyMethods Cylon.Sphero.Commands, @connection, Sphero
+      @proxyMethods Cylon.Sphero.Commands, @connection, this
 
     commands: -> Cylon.Sphero.Commands
 


### PR DESCRIPTION
Revise proxy to attach functions to objects directly instead of their prototypes.
