### PR TITLE
wait for the new spheron open callback

### DIFF
--- a/dist/adaptor.js
+++ b/dist/adaptor.js
@@ -63,10 +63,11 @@
         });
         this.sphero.open(this.connection.port.toString(), function(err) {
           if (err) {
-            return callback(err);
+            _this.connection.emit('err', err);
+          } else {
+            _this.connection.emit('connect');
           }
-          callback(null);
-          return _this.connection.emit('connect');
+          return callback(err);
         });
         return true;
       };

--- a/src/adaptor.coffee
+++ b/src/adaptor.coffee
@@ -37,9 +37,11 @@ namespace "Cylon.Adaptor", ->
 
       @sphero.open(@connection.port.toString(), (err) =>
         if err
-          return (callback)(err)
-        (callback)(null)
-        @connection.emit 'connect'
+          @connection.emit 'err', err
+        else
+          @connection.emit 'connect'
+ 
+        (callback)(err) 
       )
 
       true


### PR DESCRIPTION
This pull request adds code that waits for the proposed [spheron open callback](https://github.com/hybridgroup/spheron/pull/2) to finish it's connection via SerialPort before emitting 'connect'.
