### PR TITLE
Fix quaternion access

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -135,8 +135,8 @@ Adaptor.prototype.setDataStreaming = function(dataSources, opts) {
       pcnt = opts.pcnt || 0;
 
   dataSources.forEach(function(ds) {
-    this.mask1 = (DATA_SOURCES1[ds]) ? this.mask1 ^ DATA_SOURCES1[ds] : this.mask1;
-    this.mask2 = (DATA_SOURCES2[ds]) ? this.mask2 ^ DATA_SOURCES2[ds] : this.mask2;
+    this.mask1 = (DATA_SOURCES1[ds]) ? this.mask1 + DATA_SOURCES1[ds] : this.mask1;
+    this.mask2 = (DATA_SOURCES2[ds]) ? this.mask2 + DATA_SOURCES2[ds] : this.mask2;
   }.bind(this));
 
   this.sphero.setDataStreaming(n, m, this.mask1, pcnt, this.mask2);


### PR DESCRIPTION
Building mask/mask2 via ^ (XOR) throws an error "value out of bounds" in this.sphero.setDataStreaming() when accessing "quaternion" (wich means DATA_SOURCES2 = ["0xF0000000", ...]). 

Reason: After adding DATA_SOURCES2 with ["0xF0000000", ...](a leading f) to a mask, JS is interpreting the mask as a negative number, wich causes the bug in this.sphero.setDataStreaming(), when it calls packet.DATA.writeUInt32BE(mask2, 9).

My first pull request (yesterday), didn't fix the bug -> it just used the wrong positions in the buffer for quaternion access.
