### PR TITLE
updated README for clearer instructions on pairing Sphero with OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ In order to allow Cylon.js running on your Mac to access the Sphero, go to "Blue
 
 Thank you to [@kopipejst](https://github.com/kopipejst) for the above connnection info.
 
+First pair your computer and Sphero. You can do this using bluetooth preferences. (Sphero won't stay connected)
+
+Find out serial port address by running this command:
+
+```
+ls /dev/tty.Sphero*
+```
+The port will look something like this:
+
+```
+/dev/tty.Sphero-BBP-AMP-SPP
+```
+
+Now you are ready to run the example code, be sure to update this line with correct port:
+
+```
+connection :sphero, :adaptor => :sphero, :port => '/dev/tty.Sphero-BBP-AMP-SPP'
+```
+
 ### Ubuntu
 
 Connecting to the Sphero from Ubuntu or any other Linux-based OS can be done entirely from the command line


### PR DESCRIPTION
Thanks for your wonderful work on Cylon!

These instructions actually appear on the Artoo.io website and are necessary for Cylon as well when connecting to Sphero via OSX. If you merge this, can you please update the Cylon website as well?

Thanks!
